### PR TITLE
PCE TLS/proxy settings

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -2,6 +2,7 @@
 # .ansible-lint
 exclude_paths:
   - ${HOME}/.cache/
+  - .cache/
   - venv/
   - .github/
   - molecule/

--- a/.ansible-lint
+++ b/.ansible-lint
@@ -5,6 +5,8 @@ exclude_paths:
   - venv/
   - .github/
   - molecule/
+  - local/
+  - demo/
 
 use_default_rules: true
 

--- a/.github/workflows/sanity.yml
+++ b/.github/workflows/sanity.yml
@@ -8,32 +8,15 @@ on:
 
 jobs:
   ansible-lint:
-    name: ansible-lint ${{ matrix.ansible }}+py${{ matrix.python }}
-    strategy:
-      matrix:
-        ansible:
-          - stable-2.12
-          - stable-2.13
-          - stable-2.14
-          - stable-2.15
-        python:
-          - "3.9"
+    name: Ansible Lint
     runs-on: ubuntu-latest
     steps:
 
       - name: Check out code
         uses: actions/checkout@v3
 
-      - name: Set up Python ${{ matrix.ansible }}
-        uses: actions/setup-python@v4
-        with:
-          python-version: ${{ matrix.python }}
-
-      - name: Install ansible-base ${{ matrix.ansible }}
-        run: pip install ansible-lint yamllint https://github.com/ansible/ansible/archive/${{ matrix.ansible }}.tar.gz --disable-pip-version-check
-
       - name: Run ansible-lint
-        run: ansible-lint --force-color -v
+        uses: ansible/ansible-lint-action@v6
 
   sanity:
     name: Sanity ${{ matrix.ansible }}+py${{ matrix.python }}

--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,4 @@ _version.py
 
 # local testing files
 local/
+demo/

--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,6 @@ _version.py
 # local testing files
 local/
 demo/
+
+# ansible-lint
+.cache/

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,9 +5,20 @@
 Version 0.2.6 (TBD)
 -------------------
 
+* increment `illumio` python library version requirement to 1.1.3
+
 FEATURES:
 
 * Label module - create/update/delete label objects in the PCE
+
+IMPROVEMENTS:
+
+* add the following options to all PCE modules:
+    * `pce_tls_verify` - flag denoting whether TLS verification should be enabled on the PCE connection
+    * `pce_tls_ca` - path to a custom root CA certificate bundle to use for the PCE connection
+    * `pce_tls_client_certs` - paths to client-side certificate files
+    * `pce_http_proxy` - HTTP proxy server to use when connecting to the PCE
+    * `pce_https_proxy` - HTTPS proxy server to use when connecting to the PCE
 
 Version 0.2.5 (June 12, 2023)
 -----------------------------

--- a/README.md
+++ b/README.md
@@ -46,10 +46,10 @@ Python version **3.8** or higher is required for this collection.
 
 **Python**  
 
-For most components, you will need the `illumio` Python library version **1.1.1** or higher installed on the Ansible controller:  
+For most components, you will need the `illumio` Python library version **1.1.3** or higher installed on the Ansible controller:  
 
 ```sh
-$ pip install illumio>=1.1.1
+$ pip install illumio>=1.1.3
 ```
 
 For Windows hosts, you will also need to install the `pywinrm` library on the Ansible controller:

--- a/docs/CVEN_ROLE.md
+++ b/docs/CVEN_ROLE.md
@@ -30,6 +30,8 @@ PCE Version  | CVEN 19.3.6 | CVEN 21.1 | CVEN 21.2 | CVEN 21.5
 ------------ | :---------: | :-------: | :-------: | :-------:
 21.2         | X           | X         | X         | 
 21.5         | X           | X         | X         | X
+22.2         | X           | X         | X         | X
+22.5         | X           | X         | X         | X
 
 ## Installation  
 
@@ -83,6 +85,11 @@ Variable | Description | Data Type | Environment variable | Default value
 `illumio_pce_org_id` | PCE Organization ID | `int` | `ILLUMIO_PCE_ORG_ID` | `1`
 `illumio_pce_api_key` | PCE API key | `str` | `ILLUMIO_API_KEY_USERNAME` | -
 `illumio_pce_api_secret` | PCE API secret | `str` | `ILLUMIO_API_KEY_SECRET` | -
+`illumio_pce_tls_verify` | Enable/disable TLS verification | `bool` | - | `true`
+`illumio_pce_tls_ca` | Custom root CA path. If set, overrides `illumio_pce_tls_verify` | `str` | - | -
+`illumio_pce_tls_client_certs` | TLS client cert paths. Can point to a single PEM file containing public/private pair or two separate files | `list` | - | -
+`illumio_pce_http_proxy` | HTTP proxy server | `str` | `http_proxy` | -
+`illumio_pce_https_proxy` | HTTPS proxy server | `str` | `https_proxy` | -
 
 ### Kubelink  
 

--- a/docs/KUBELINK_ROLE.md
+++ b/docs/KUBELINK_ROLE.md
@@ -31,6 +31,8 @@ PCE Version  | Kubelink 2.0 | Kubelink 2.1
 ------------ | :----------: | :---------: 
 21.2         | X            | 
 21.5         | X            | X
+22.2         | X            | X
+22.5         | X            | X
 
 ## Installation  
 
@@ -98,6 +100,11 @@ Variable | Description | Data Type | Environment variable | Default value
 `illumio_pce_org_id` | PCE Organization ID | `int` | `ILLUMIO_PCE_ORG_ID` | `1`
 `illumio_pce_api_key` | PCE API key | `str` | `ILLUMIO_API_KEY_USERNAME` | -
 `illumio_pce_api_secret` | PCE API secret | `str` | `ILLUMIO_API_KEY_SECRET` | -
+`illumio_pce_tls_verify` | Enable/disable TLS verification | `bool` | - | `true`
+`illumio_pce_tls_ca` | Custom root CA path. If set, overrides `illumio_pce_tls_verify` | `str` | - | -
+`illumio_pce_tls_client_certs` | TLS client cert paths. Can point to a single PEM file containing public/private pair or two separate files | `list` | - | -
+`illumio_pce_http_proxy` | HTTP proxy server | `str` | `http_proxy` | -
+`illumio_pce_https_proxy` | HTTPS proxy server | `str` | `https_proxy` | -
 
 ### Container Cluster  
 

--- a/docs/VEN_ROLE.md
+++ b/docs/VEN_ROLE.md
@@ -39,10 +39,12 @@ This role will work with the following operating systems (see the compatibility 
 
 ### VEN Compatibility  
 
-PCE Version  | VEN 21.2.5 | VEN 21.5.20
------------- | :--------: | :---------: 
-21.2         | X          | 
-21.5         | X          | X
+PCE Version  | VEN 21.2.x | VEN 21.5.x | VEN 22.2.x | VEN 22.5.22
+------------ | :--------: | :--------: | :--------: | :---------:
+21.2         | X          |            |            | 
+21.5         | X          | X          |            | 
+22.2         | X          | X          | X          | 
+22.5         | X          | X          | X          | X
 
 See the [Illumio Support dependencies page](https://support.illumio.com/software/os-support-package-dependencies/ven.html) for specific VEN OS compatibility details.  
 
@@ -112,6 +114,11 @@ Variable | Description | Data Type | Environment variable | Default value
 `illumio_pce_org_id` | PCE Organization ID | `int` | `ILLUMIO_PCE_ORG_ID` | `1`
 `illumio_pce_api_key` | PCE API key | `str` | `ILLUMIO_API_KEY_USERNAME` | -
 `illumio_pce_api_secret` | PCE API secret | `str` | `ILLUMIO_API_KEY_SECRET` | -
+`illumio_pce_tls_verify` | Enable/disable TLS verification | `bool` | - | `true`
+`illumio_pce_tls_ca` | Custom root CA path. If set, overrides `illumio_pce_tls_verify` | `str` | - | -
+`illumio_pce_tls_client_certs` | TLS client cert paths. Can point to a single PEM file containing public/private pair or two separate files | `list` | - | -
+`illumio_pce_http_proxy` | HTTP proxy server | `str` | `http_proxy` | -
+`illumio_pce_https_proxy` | HTTPS proxy server | `str` | `https_proxy` | -
 
 ### Pairing profile  
 

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -18,6 +18,9 @@ dependencies:
   community.general: '*'
   kubernetes.core: '*'
 repository: https://github.com/illumio/illumio.core
+documentation: https://github.com/illumio/illumio.core
+homepage: https://github.com/illumio/illumio.core
+issues: https://github.com/illumio/illumio.core/issues
 build_ignore:
   - '.github'
   - '.gitignore'

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -28,6 +28,7 @@ build_ignore:
   - 'build'
   - 'dist'
   - 'local'
+  - 'demo'
   - 'venv'
   - 'molecule'
   - '**/integration_config.yml'

--- a/plugins/doc_fragments/pce.py
+++ b/plugins/doc_fragments/pce.py
@@ -42,4 +42,30 @@ options:
       - Can be set with the environment variable C(ILLUMIO_API_KEY_SECRET).
     type: str
     required: true
+  pce_tls_verify:
+    description:
+      - Flag denoting whether TLS verification should be enabled on the PCE connection.
+    type: bool
+    default: true
+  pce_tls_ca:
+    description:
+      - Path to a custom root CA certificate bundle to use for the PCE connection.
+      - If set, overrides C(pce_tls_verify).
+    type: str
+  pce_tls_client_certs:
+    description:
+      - Optional paths to client-side certificate files.
+      - May point to separate cert and private key files or a PEM bundle containing both.
+    type: list
+    elements: str
+  pce_http_proxy:
+    description:
+      - HTTP proxy server to use when connecting to the PCE.
+      - If not set, it will use the default C(http_proxy) environment variable.
+    type: str
+  pce_https_proxy:
+    description:
+      - HTTPS proxy server to use when connecting to the PCE.
+      - If not set, it will use the default C(https_proxy) environment variable.
+    type: str
 '''

--- a/plugins/module_utils/pce.py
+++ b/plugins/module_utils/pce.py
@@ -70,7 +70,7 @@ class PceApiBase(object):
         try:
             self._pce.must_connect()
         except Exception as e:
-            module.fail_json("Failed to establish a connection to the PCE: {}".format(str(e)))
+            module.fail_json("Failed to establish a connection to the PCE: %s" % (str(e)))
 
 
 class PceObjectApi(PceApiBase, metaclass=ABCMeta):

--- a/plugins/module_utils/pce.py
+++ b/plugins/module_utils/pce.py
@@ -67,8 +67,10 @@ class PceApiBase(object):
                 https_proxy=pce_https_proxy
             )
 
-        if not self._pce.check_connection():
-            module.fail_json("Failed to establish a connection to the PCE.")
+        try:
+            self._pce.must_connect()
+        except Exception as e:
+            module.fail_json("Failed to establish a connection to the PCE: {}".format(str(e)))
 
 
 class PceObjectApi(PceApiBase, metaclass=ABCMeta):

--- a/plugins/modules/container_cluster.py
+++ b/plugins/modules/container_cluster.py
@@ -20,7 +20,7 @@ author:
   - Duncan Sommerville (@dsommerville-illumio)
 requirements:
   - "python>=3.8"
-  - "illumio>=1.1.1"
+  - "illumio>=1.1.3"
 version_added: "0.2.0"
 
 options:

--- a/plugins/modules/label.py
+++ b/plugins/modules/label.py
@@ -18,7 +18,7 @@ author:
   - Duncan Sommerville (@dsommerville-illumio)
 requirements:
   - "python>=3.8"
-  - "illumio>=1.1.1"
+  - "illumio>=1.1.3"
 version_added: "0.3.0"
 
 options:

--- a/plugins/modules/pairing_key.py
+++ b/plugins/modules/pairing_key.py
@@ -19,7 +19,7 @@ author:
   - Duncan Sommerville (@dsommerville-illumio)
 requirements:
   - "python>=3.8"
-  - "illumio>=1.1.1"
+  - "illumio>=1.1.3"
 version_added: "0.2.0"
 
 options:

--- a/plugins/modules/pairing_profile.py
+++ b/plugins/modules/pairing_profile.py
@@ -18,7 +18,7 @@ author:
   - Duncan Sommerville (@dsommerville-illumio)
 requirements:
   - "python>=3.8"
-  - "illumio>=1.1.1"
+  - "illumio>=1.1.3"
 version_added: "0.2.0"
 
 options:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-illumio>=1.1.1
+illumio>=1.1.3

--- a/requirements.yml
+++ b/requirements.yml
@@ -1,6 +1,0 @@
----
-collections:
-
-- ansible.windows
-- community.general
-- kubernetes.core

--- a/requirements.yml
+++ b/requirements.yml
@@ -1,0 +1,6 @@
+---
+collections:
+
+- ansible.windows
+- community.general
+- kubernetes.core

--- a/roles/cven/tasks/main.yml
+++ b/roles/cven/tasks/main.yml
@@ -6,6 +6,11 @@
     pce_org_id: "{{ illumio_pce_org_id }}"
     api_key_username: "{{ illumio_pce_api_key }}"
     api_key_secret: "{{ illumio_pce_api_secret }}"
+    pce_tls_verify: "{{ illumio_pce_tls_verify | default(omit) }}"
+    pce_tls_ca: "{{ illumio_pce_tls_ca | default(omit) }}"
+    pce_tls_client_certs: "{{ illumio_pce_tls_client_certs | default(omit) }}"
+    pce_http_proxy: "{{ illumio_pce_http_proxy | default(omit) }}"
+    pce_https_proxy: "{{ illumio_pce_https_proxy | default(omit) }}"
     name: "{{ illumio_cven_profile_name }}"
     description: "{{ illumio_cven_profile_description }}"
     enabled: true
@@ -24,6 +29,11 @@
     pce_org_id: "{{ illumio_pce_org_id }}"
     api_key_username: "{{ illumio_pce_api_key }}"
     api_key_secret: "{{ illumio_pce_api_secret }}"
+    pce_tls_verify: "{{ illumio_pce_tls_verify | default(omit) }}"
+    pce_tls_ca: "{{ illumio_pce_tls_ca | default(omit) }}"
+    pce_tls_client_certs: "{{ illumio_pce_tls_client_certs | default(omit) }}"
+    pce_http_proxy: "{{ illumio_pce_http_proxy | default(omit) }}"
+    pce_https_proxy: "{{ illumio_pce_https_proxy | default(omit) }}"
     pairing_profile_href: "{{ cven_pairing_profile_result.pairing_profile['href'] }}"
   delegate_to: '127.0.0.1'
   register: cven_pairing_key_result

--- a/roles/kubelink/tasks/container_cluster.yml
+++ b/roles/kubelink/tasks/container_cluster.yml
@@ -11,6 +11,11 @@
     pce_org_id: "{{ illumio_pce_org_id }}"
     api_key_username: "{{ illumio_pce_api_key }}"
     api_key_secret: "{{ illumio_pce_api_secret }}"
+    pce_tls_verify: "{{ illumio_pce_tls_verify | default(omit) }}"
+    pce_tls_ca: "{{ illumio_pce_tls_ca | default(omit) }}"
+    pce_tls_client_certs: "{{ illumio_pce_tls_client_certs | default(omit) }}"
+    pce_http_proxy: "{{ illumio_pce_http_proxy | default(omit) }}"
+    pce_https_proxy: "{{ illumio_pce_https_proxy | default(omit) }}"
     name: "{{ kubelink_cluster_name }}"
     description: Container cluster created by Ansible
     state: present

--- a/roles/ven/tasks/manage_ven_linux.yml
+++ b/roles/ven/tasks/manage_ven_linux.yml
@@ -5,6 +5,21 @@
   tags:
     - always
 
+- name: "Stat VEN control tool"
+  become: true
+  ansible.builtin.stat:
+    path: "{{ ven_ctl }}"
+  register: ven_cli
+  tags:
+    - always
+
+- name: "Fail on missing VEN control tool"
+  ansible.builtin.fail:
+    msg: "Missing VEN control tool at {{ ven_ctl }}"
+  when: not ven_cli.stat.exists
+  tags:
+    - always
+
 - name: "Start VEN"
   become: true
   ansible.builtin.command: "{{ ven_ctl }} start"
@@ -68,17 +83,8 @@
     - never
     - ven_unpair
 
-- name: "Stat VEN control tool"
-  become: true
-  ansible.builtin.stat:
-    path: "{{ ven_ctl }}"
-  register: ven_cli
-  tags:
-    - always
-    - ven_status
-
 - name: "Check VEN status"
-  when: ven_cli.stat.exists
+  when: "'ven_unpair' not in ansible_run_tags"
   tags:
     - always
     - ven_status

--- a/roles/ven/tasks/manage_ven_windows.yml
+++ b/roles/ven/tasks/manage_ven_windows.yml
@@ -5,6 +5,21 @@
   tags:
     - always
 
+- name: "Stat VEN control tool"
+  become: true
+  ansible.windows.win_stat:
+    path: "{{ ven_ctl }}"
+  register: ven_cli
+  tags:
+    - always
+
+- name: "Fail on missing VEN control tool"
+  ansible.builtin.fail:
+    msg: "Missing VEN control tool at {{ ven_ctl }}"
+  when: not ven_cli.stat.exists
+  tags:
+    - always
+
 - name: "Start VEN"
   become: true
   ansible.windows.win_command: powershell.exe -file "{{ ven_ctl }}" start
@@ -68,17 +83,8 @@
     - never
     - ven_unpair
 
-- name: "Stat VEN control tool"
-  become: true
-  ansible.windows.win_stat:
-    path: "{{ ven_ctl }}"
-  register: ven_cli
-  tags:
-    - always
-    - ven_status
-
 - name: "Check VEN status"
-  when: ven_cli.stat.exists
+  when: "'ven_unpair' not in ansible_run_tags"
   tags:
     - always
     - ven_status

--- a/roles/ven/tasks/pairing_profile.yml
+++ b/roles/ven/tasks/pairing_profile.yml
@@ -7,6 +7,11 @@
     pce_org_id: "{{ illumio_pce_org_id }}"
     api_key_username: "{{ illumio_pce_api_key }}"
     api_key_secret: "{{ illumio_pce_api_secret }}"
+    pce_tls_verify: "{{ illumio_pce_tls_verify | default(omit) }}"
+    pce_tls_ca: "{{ illumio_pce_tls_ca | default(omit) }}"
+    pce_tls_client_certs: "{{ illumio_pce_tls_client_certs | default(omit) }}"
+    pce_http_proxy: "{{ illumio_pce_http_proxy | default(omit) }}"
+    pce_https_proxy: "{{ illumio_pce_https_proxy | default(omit) }}"
     name: "{{ illumio_ven_profile_name }}"
     description: "{{ illumio_ven_profile_description }}"
     enforcement_mode: "{{ illumio_ven_enforcement_mode }}"
@@ -29,6 +34,11 @@
     pce_org_id: "{{ illumio_pce_org_id }}"
     api_key_username: "{{ illumio_pce_api_key }}"
     api_key_secret: "{{ illumio_pce_api_secret }}"
+    pce_tls_verify: "{{ illumio_pce_tls_verify | default(omit) }}"
+    pce_tls_ca: "{{ illumio_pce_tls_ca | default(omit) }}"
+    pce_tls_client_certs: "{{ illumio_pce_tls_client_certs | default(omit) }}"
+    pce_http_proxy: "{{ illumio_pce_http_proxy | default(omit) }}"
+    pce_https_proxy: "{{ illumio_pce_https_proxy | default(omit) }}"
     pairing_profile_name: "{{ illumio_ven_profile_name }}"
   delegate_to: '127.0.0.1'
   register: ven_pairing_key_result


### PR DESCRIPTION
* extend PCE util with TLS and proxy vars
* update roles and modules to use PCE TLS/proxy vars
* bump `illumio` min version to v1.1.3
* raise more verbose errors for PCE connection failures

- [x] I've read and followed the [contribution guidelines](CONTRIBUTING.md) for this PR  